### PR TITLE
_eventsCount is dynamically added by node emitter. Given that the gen…

### DIFF
--- a/src/yang.coffee
+++ b/src/yang.coffee
@@ -27,6 +27,7 @@ class Model extends Emitter
       '__':  value: { name: schema.tag, schema: schema }
       '__props__': value: {}
       '_events':   writable: true
+      '_eventsCount':   writable: true
     for k, prop of data.__props__ when (@access k)?
       prop.parent = this
       @__props__[k] = prop


### PR DESCRIPTION
…erated models are protected against any leak, need to add this property to the model for events to work.