### PR TITLE
Enhance if-feature to comply with YANG1.1, additional npm package:voll

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "promise": "^7.1.1",
     "semver": "^5.3.0",
     "stacktrace-parser": "^0.1.4",
+    "voll": "^1.2.2",
     "yang-parser": "^0.1.2"
   },
   "devDependencies": {

--- a/src/lang/extensions.coffee
+++ b/src/lang/extensions.coffee
@@ -2,7 +2,7 @@ Yang  = require '../yang'
 Model = require '../model'
 XPath = require '../xpath'
 Extension = require '../extension'
-
+Voll = require 'voll'
 assert = require 'assert'
 
 STRIP_COMMENTS = /(\/\/.*$)|(\/\*[\s\S]*?\*\/)|(\s*=[^,\)]*(('(?:\\'|[^'\r\n])*')|("(?:\\"|[^"\r\n])*"))|(\s*=[^,\)]*))/mg
@@ -401,8 +401,18 @@ module.exports = [
   new Extension 'if-feature',
     argument: 'feature-name'
     transform: (data) ->
-      feature = @lookup 'feature', @tag
-      return data if feature?.binding?
+      voll_input = ((@tag.replace /and/g, "AND").replace /or/g, "OR").replace /not/g, "NOT"
+      voll_instance = Voll voll_input
+      feature_elements = @tag.split(/\(|\)|and|or|not/)
+      control_string = ""
+
+      for feature_element in feature_elements
+        feature_name = feature_element.replace(/\s/g, '')
+        unless feature_name == ''
+          feature = @lookup 'feature', feature_name
+          control_string += (feature_name + " ") if feature?.binding?
+
+      return data if voll_instance control_string
 
   new Extension 'import',
     argument: 'module'


### PR DESCRIPTION
I use [voll package](https://www.npmjs.com/package/voll) to handle the logic expression of the `if-feature` arguments. 

After extracting all the mentioned features, I reuse the origin code to build my logic control string:
```js
feature = @lookup 'feature', feature_name
control_string += (feature_name + " ") if feature?.binding?
```
Any feature name appears in the control_string stands for `true` otherwise `false`

I am not sure if you accept other `npm` packages as dependencies. 

Hope this help.