### PR TITLE
bug-fix: identifier expression of 'augment' in 'uses'

### DIFF
--- a/src/lang/extensions.coffee
+++ b/src/lang/extensions.coffee
@@ -89,7 +89,7 @@ module.exports = [
             throw @error "'#{@tag}' must be absolute-schema-path to augment within module statement"
           @locate @tag
         when 'uses'
-          if /^\//.test @tag
+          unless /^[_0-9a-zA-Z]/.test @tag
             throw @error "'#{@tag}' must be relative-schema-path to augment within uses statement"
           @parent.state.grouping.locate @tag
       unless target?


### PR DESCRIPTION
According to [RFC](https://tools.ietf.org/html/rfc7950#section-7.17), I think the starting pattern of this argument should be `^[0-9a-zA-Z]` 