### PR TITLE
fixes #64, make yang-js to support windows platform.

### DIFF
--- a/src/yang.litcoffee
+++ b/src/yang.litcoffee
@@ -129,8 +129,8 @@ same folder that the `resolve` request was made: `#{name}.yang`.
         dir = from = switch
           when from.length then from[0]
           else path.resolve()
-        while not found? and dir not in [ '/', '.' ]
-          target = "#{dir}/package.json"
+        while not found? and dir != path.dirname dir
+          target = path.resolve dir, "package.json"
           debug? "[resolve] #{name} in #{target}"
           try
             pkginfo = require(target)


### PR DESCRIPTION
It removes the hardcoded root dir and package.json file path.
It will make yang-js support Windows platform, which was tested on Windows 10 enterprise 1803.