### PR TITLE
Add basic type declaration file to yang-js.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for yang-js
+// Project: yang-js
+// Definitions by: quan.tang
+
+export function parse(schema: string): YangInstance;
+export function compose(data: any): YangInstance;
+export function resolve(name: any): YangInstance;
+export function clear(): void;
+
+
+export interface YangInstance {
+    bind(obj: any): this;
+    eval(data?: any): YangModel;
+    validate(data: any): any;
+    extends(schema: string): this;
+}
+
+export interface YangModel extends YangProperty {
+    access(model: string): YangModel;
+    on(event: string, path: string, callback: any);
+}
+
+export interface YangProperty {
+    name: string;
+    parent: YangProperty;
+    path: YangXPath;
+    children: YangProperty[];
+    change: any[];
+
+    get(key?: string): any;
+    set(value: any): this;
+    merge(value: any): this;
+    create(data: any): this;
+    find(pattern?: string): YangProperty;
+    in(pattern?: string): YangProperty;
+    do(): Promise<any>;
+    toJSON(tag?: boolean): any;
+}
+
+export interface YangXPath {
+    tail: YangXPath;
+    contains(path: string): boolean;
+    locate(path: string): YangXPath;
+}
+
+export function _import(name: string): YangInstance;
+export {_import as import};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "Apache-2.0",
   "repository": "corenova/yang-js",
   "main": "index.js",
+  "types": "index.d.ts",
   "browser": "browser.js",
   "yang": {
     "resolve": {


### PR DESCRIPTION
Hi @saintkepha ,

As our main project works on Typescript, it would be better to have type information on yang-js.
I proposed an initial Typescript declaration file, please help take a look. It is based on your documentation and covers the basic usage on yang-js and some internal types.

Cheers.